### PR TITLE
fix the mismatch of Hetzner-DNS-Documentation and real API-Response

### DIFF
--- a/dns/primary_server.go
+++ b/dns/primary_server.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/jobstoit/hetzner-dns-go/dns/schema"
 )
@@ -16,8 +15,8 @@ import (
 type PrimaryServer struct {
 	ID       string
 	Port     int
-	Created  time.Time
-	Modified time.Time
+	Created  schema.HdnsTime
+	Modified schema.HdnsTime
 	Zone     *Zone
 	Address  string
 }

--- a/dns/primary_server_test.go
+++ b/dns/primary_server_test.go
@@ -90,8 +90,8 @@ func TestPrimaryServerCreate(t *testing.T) {
 		respBody.PrimaryServer = schema.PrimaryServer{
 			ID:       "1",
 			Port:     body.Port,
-			Created:  time.Now(),
-			Modified: time.Now(),
+			Created:  schema.HdnsTime(time.Now()),
+			Modified: schema.HdnsTime(time.Now()),
 			ZoneID:   body.ZoneID,
 			Address:  body.Address,
 		}
@@ -135,8 +135,8 @@ func TestPrimaryServerUpdate(t *testing.T) {
 		respBody.PrimaryServer = schema.PrimaryServer{
 			ID:       "1",
 			Port:     body.Port,
-			Created:  time.Now(),
-			Modified: time.Now(),
+			Created:  schema.HdnsTime(time.Now()),
+			Modified: schema.HdnsTime(time.Now()),
 			ZoneID:   body.ZoneID,
 			Address:  body.Address,
 		}

--- a/dns/records.go
+++ b/dns/records.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/jobstoit/hetzner-dns-go/dns/schema"
 )
@@ -36,8 +35,8 @@ const (
 type Record struct {
 	Type     RecordType
 	ID       string
-	Created  time.Time
-	Modified time.Time
+	Created  schema.HdnsTime
+	Modified schema.HdnsTime
 	Zone     *Zone
 	Name     string
 	Value    string

--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -1,0 +1,33 @@
+package schema
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// HdnsTime defines a wrapper for time.Time, to handle the DateTime format used in HCloud DNS API
+type HdnsTime time.Time
+
+func (ht *HdnsTime) UnmarshalJSON(b []byte) (err error) {
+	hdns_time_layout := "2006-01-02 15:04:05 -0700 UTC"
+
+	s := strings.Trim(string(b), "\"")
+
+	if len(s) == 0 {
+		*ht = HdnsTime{}
+		return nil
+	}
+
+	t, err := time.Parse(hdns_time_layout, s)
+	if err != nil {
+		return fmt.Errorf("Error while parsing date '%s' with time layout '%s': %s\n", s, hdns_time_layout, err)
+	}
+
+	*ht = HdnsTime(t)
+	return nil
+}
+
+func (ht HdnsTime) MarshalJSON() ([]byte, error) {
+	return time.Time(ht).MarshalJSON()
+}

--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -21,7 +21,12 @@ func (ht *HdnsTime) UnmarshalJSON(b []byte) (err error) {
 
 	t, err := time.Parse(hdns_time_layout, s)
 	if err != nil {
-		return fmt.Errorf("Error while parsing date '%s' with time layout '%s': %s\n", s, hdns_time_layout, err)
+		t2, err2 := time.Parse(time.RFC3339, s)
+
+		if err2 != nil {
+			return fmt.Errorf("Error while parsing date '%s' with default rfc3339 time layout and '%s': %s\n", s, hdns_time_layout, err)
+		}
+		t = t2
 	}
 
 	*ht = HdnsTime(t)

--- a/dns/schema/primary_server.go
+++ b/dns/schema/primary_server.go
@@ -1,15 +1,13 @@
 package schema
 
-import "time"
-
 // PrimaryServer represents a primary server in the Hetzner DNS API.
 type PrimaryServer struct {
-	ID       string    `json:"id"`
-	Port     int       `json:"port"`
-	Created  time.Time `json:"created"`
-	Modified time.Time `json:"modified"`
-	ZoneID   string    `json:"zone_id"`
-	Address  string    `json:"address"`
+	ID       string   `json:"id"`
+	Port     int      `json:"port"`
+	Created  HdnsTime `json:"created"`
+	Modified HdnsTime `json:"modified"`
+	ZoneID   string   `json:"zone_id"`
+	Address  string   `json:"address"`
 }
 
 // PrimaryServerListResponse defines the schema of the response when

--- a/dns/schema/records.go
+++ b/dns/schema/records.go
@@ -1,17 +1,15 @@
 package schema
 
-import "time"
-
 // Record represents a record in Hetzner DNS.
 type Record struct {
-	Type     string    `json:"type"`
-	ID       string    `json:"id"`
-	Created  time.Time `json:"created"`
-	Modified time.Time `json:"modified"`
-	ZoneID   string    `json:"zone_id"`
-	Name     string    `json:"name"`
-	Value    string    `json:"value"`
-	Ttl      int       `json:"ttl"`
+	Type     string   `json:"type"`
+	ID       string   `json:"id"`
+	Created  HdnsTime `json:"created"`
+	Modified HdnsTime `json:"modified"`
+	ZoneID   string   `json:"zone_id"`
+	Name     string   `json:"name"`
+	Value    string   `json:"value"`
+	Ttl      int      `json:"ttl"`
 }
 
 // RecordListResponse defines the schema of the response when

--- a/dns/schema/zones.go
+++ b/dns/schema/zones.go
@@ -1,7 +1,5 @@
 package schema
 
-import "time"
-
 // ZoneListResponse defines the schema of the response when
 // listing zones.
 type ZoneListResponse struct {
@@ -17,8 +15,8 @@ type ZoneResponse struct {
 // Zone represents a zone in Hetzner DNS.
 type Zone struct {
 	ID              string          `json:"id"`
-	Created         time.Time       `json:"created"`
-	Modified        time.Time       `json:"modified"`
+	Created         HdnsTime        `json:"created"`
+	Modified        HdnsTime        `json:"modified"`
 	LegacyDNSHost   string          `json:"legacy_dns_host"`
 	LegacyNS        []string        `json:"legacy_ns"`
 	Name            string          `json:"name"`
@@ -30,7 +28,7 @@ type Zone struct {
 	Registrar       string          `json:"registrar"`
 	Status          string          `json:"status"`
 	Ttl             int             `json:"ttl"`
-	Verified        time.Time       `json:"verified"`
+	Verified        HdnsTime        `json:"verified"`
 	RecordsCount    int             `json:"records_count"`
 	IsSecondaryDNS  bool            `json:"is_secondary_dns"`
 	TxtVerification TxtVerification `json:"txt_verification"`

--- a/dns/zones.go
+++ b/dns/zones.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"time"
 
 	"github.com/jobstoit/hetzner-dns-go/dns/schema"
 )
@@ -24,8 +23,8 @@ const (
 // Zone represents a zone in Hetzner DNS.
 type Zone struct {
 	ID              string
-	Created         time.Time
-	Modified        time.Time
+	Created         schema.HdnsTime
+	Modified        schema.HdnsTime
 	LegacyDNSHost   string
 	LegacyNS        []string
 	Name            string
@@ -37,7 +36,7 @@ type Zone struct {
 	Registrar       string
 	Status          ZoneStatus
 	Ttl             int
-	Verified        time.Time
+	Verified        schema.HdnsTime
 	RecordsCount    int
 	IsSecondaryDNS  bool
 	TxtVerification *TxtVerification


### PR DESCRIPTION
The Hetzner DNS-API states the timeformat in responses is RFC3339, but it is actually not.
As soon as this changes, I will open another PR, but for now, we need to account for the other DateTime format.

Just FYI @jobstoit : I'm planning to integrate this little golang lib into [external-dns for kubernetes](https://github.com/kubernetes-sigs/external-dns), I hope you are fine with that. Let me know if you are not, but I didn't see the necessity to create another golang implementation for the Hetzner-DNS-API, when you already got one here.

Best regards,
Jonas