### PR TITLE
fix(HdnsTime): add 3rd possible format

### DIFF
--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -11,12 +11,12 @@ type HdnsTime time.Time
 
 func (ht *HdnsTime) UnmarshalJSON(b []byte) error {
 
-	s := strings.Trim(string(b), "\"")
-
-	if len(s) == 0 {
+	if len(b) == 0 {
 		*ht = HdnsTime{}
 		return nil
 	}
+
+	s := strings.Trim(string(b), "\"")
 
 	hdns_time_layout_1 := "2006-01-02 15:04:05 -0700 UTC"
 

--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -29,7 +29,7 @@ func (ht *HdnsTime) UnmarshalJSON(b []byte) error {
 	// [...] "verified": "2020-04-07 01:56:03.196438163 +0000 UTC m=+755.322810452", [...]
 	hdns_time_layout_2 := "2006-01-02 15:04:05.000000000 -0700 UTC" //... m=+755.322810452"
 
-	if t, err := time.Parse(hdns_time_layout_2, s); err == nil {
+	if t, err := time.Parse(hdns_time_layout_2, strings.Split(s, " m=+")[0]); err == nil {
 		*ht = HdnsTime(t)
 		return nil
 	}

--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -6,11 +6,14 @@ import (
 	"time"
 )
 
-// HdnsTime defines a wrapper for time.Time, to handle the DateTime format used in HCloud DNS API
+// HdnsTime defines a wrapper for time.Time, to handle the DateTime format(s) used in HCloud DNS API...
 type HdnsTime time.Time
 
-func (ht *HdnsTime) UnmarshalJSON(b []byte) (err error) {
-	hdns_time_layout := "2006-01-02 15:04:05 -0700 UTC"
+func (ht *HdnsTime) UnmarshalJSON(b []byte) error {
+	hdns_time_layout_1 := "2006-01-02 15:04:05 -0700 UTC"
+	// Real example API return value:
+	// [...] "verified": "2020-04-07 01:56:03.196438163 +0000 UTC m=+755.322810452", [...]
+	hdns_time_layout_2 := "2006-01-02 15:04:05.000000000 -0700 UTC" //... m=+755.322810452"
 
 	s := strings.Trim(string(b), "\"")
 
@@ -19,14 +22,21 @@ func (ht *HdnsTime) UnmarshalJSON(b []byte) (err error) {
 		return nil
 	}
 
-	t, err := time.Parse(hdns_time_layout, s)
-	if err != nil {
-		t2, err2 := time.Parse(time.RFC3339, s)
+	t, err_format1 := time.Parse(hdns_time_layout_1, s)
+	if err_format1 != nil {
 
-		if err2 != nil {
-			return fmt.Errorf("Error while parsing date '%s' with default rfc3339 time layout and '%s': %s\n", s, hdns_time_layout, err)
+		t_format2, err_format2 := time.Parse(hdns_time_layout_2, strings.Split(s, " m=+")[0])
+		t = t_format2
+
+		if err_format2 != nil {
+
+			time_rfc3339, err_rfc3339 := time.Parse(time.RFC3339, s)
+			t = time_rfc3339
+
+			if err_rfc3339 != nil {
+				return fmt.Errorf("Error while parsing date '%s' with\n;; '%s' (err: %s)\n;; '%s' (err: %s)\n;; default rfc3339 time layout (err: %s)\n", s, hdns_time_layout_1, err_format1, hdns_time_layout_2, err_format2, err_rfc3339)
+			}
 		}
-		t = t2
 	}
 
 	*ht = HdnsTime(t)


### PR DESCRIPTION
Since Hetzner DNS has very inconsitent time formats, this PR adds a third one I came across, that broke my eternal-dns.
A real world example (see `verified` field):
`curl -s "https://dns.hetzner.com/api/v1/zones?zone_id= [redacted]" -H 'Auth-API-Token: [redacted]' | jq`
```json
{
  "zones": [
    {
      "id": " [redacted]",
      "name": " [redacted]",
      "ttl": 7200,
      "registrar": "",
      "legacy_dns_host": "",
      "legacy_ns": [
        "ns1.your-server.de.",
        "ns3.second-ns.de.",
        "ns.second-ns.com."
      ],
      "ns": [
        "hydrogen.ns.hetzner.com",
        "oxygen.ns.hetzner.com",
        "helium.ns.hetzner.de"
      ],
      "created": "2020-04-07 01:24:37 +0000 UTC",
      "verified": "2020-04-07 01:56:03.196438163 +0000 UTC m=+755.322810452",
      "modified": "2022-12-13 01:37:45.814 +0000 UTC",
      "project": "",
      "owner": "",
      "permission": "",
      "zone_type": {
        "id": "",
        "name": "",
        "description": "",
        "prices": null
      },
      "status": "verified",
      "paused": false,
      "is_secondary_dns": false,
      "txt_verification": {
        "name": "",
        "token": ""
      },
      "records_count": 54
    }
  ],
  "meta": {
    "pagination": {
      "page": 1,
      "per_page": 100,
      "previous_page": 1,
      "next_page": 1,
      "last_page": 1,
      "total_entries": 1
    }
  }
}
```