### PR TITLE
fix(HdnsTime): check empty string byte array

### DIFF
--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -11,17 +11,12 @@ type HdnsTime time.Time
 
 func (ht *HdnsTime) UnmarshalJSON(b []byte) error {
 
-	if len(b) == 0 {
+	if len(b) == 0 || (len(b) == 2 && b[0] == 34 && b[1] == 34) {
 		*ht = HdnsTime{}
 		return nil
 	}
 
 	s := strings.Trim(string(b), "\"")
-
-	if len(s) == 0 {
-		*ht = HdnsTime{}
-		return nil
-	}
 
 	hdns_time_layout_1 := "2006-01-02 15:04:05 -0700 UTC"
 

--- a/dns/schema/hdns_time.go
+++ b/dns/schema/hdns_time.go
@@ -18,6 +18,11 @@ func (ht *HdnsTime) UnmarshalJSON(b []byte) error {
 
 	s := strings.Trim(string(b), "\"")
 
+	if len(s) == 0 {
+		*ht = HdnsTime{}
+		return nil
+	}
+
 	hdns_time_layout_1 := "2006-01-02 15:04:05 -0700 UTC"
 
 	if t, err := time.Parse(hdns_time_layout_1, s); err == nil {


### PR DESCRIPTION
Unfortunately the length check change in #2 broke the parsing of empty strings.
So I added a check for the byte array containing bytes representing the JSON empty string.

I tested it this time.